### PR TITLE
Fix non-deterministic panic count from parallel processing

### DIFF
--- a/jones/src/sym.rs
+++ b/jones/src/sym.rs
@@ -552,10 +552,12 @@ impl CallGraph {
             }
         });
 
-        // Convert DashMap to HashMap
-        Ok(Self {
-            edges: edges.into_iter().collect(),
-        })
+        // Convert DashMap to HashMap and sort each caller list for deterministic ordering
+        let mut edges: HashMap<u64, Vec<CallerInfo>> = edges.into_iter().collect();
+        for callers in edges.values_mut() {
+            callers.sort_by_key(|c| c.call_site_addr);
+        }
+        Ok(Self { edges })
     }
 
     /// Build a call graph by scanning all instructions once (no debug info).
@@ -690,9 +692,12 @@ impl CallGraph {
             );
         }
 
-        Ok(Self {
-            edges: edges.into_iter().collect(),
-        })
+        // Convert DashMap to HashMap and sort each caller list for deterministic ordering
+        let mut edges: HashMap<u64, Vec<CallerInfo>> = edges.into_iter().collect();
+        for callers in edges.values_mut() {
+            callers.sort_by_key(|c| c.call_site_addr);
+        }
+        Ok(Self { edges })
     }
 
     /// Get all callers of a target address.


### PR DESCRIPTION
## Summary
- Sort caller lists by `call_site_addr` after parallel collection to ensure deterministic ordering
- The DashMap collects entries in non-deterministic order due to thread timing, which caused different panic point counts between runs

## Testing
Before fix (10 runs):
```
Panic points: 98, 98, 97, 96, 99, 98, 97, 97, 97, 95
```

After fix (10 runs):
```
Panic points: 98, 98, 98, 98, 98, 98, 98, 98, 98, 98
```

Fixes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)