### PR TITLE
Add more panic type examples for better coverage

### DIFF
--- a/examples/panic/src/main.rs
+++ b/examples/panic/src/main.rs
@@ -14,4 +14,31 @@ fn main() {
 
     // jones: expect panic - This obviously causes a panic
     module::cause_an_unwrap();
+
+    // jones: expect panic - unwrap on Err
+    module::cause_unwrap_err();
+
+    // jones: expect panic - assert failed
+    module::cause_assert();
+
+    // jones: expect panic - debug_assert failed
+    module::cause_debug_assert();
+
+    // jones: expect panic - unreachable
+    module::cause_unreachable();
+
+    // jones: expect panic - unimplemented
+    module::cause_unimplemented();
+
+    // jones: expect panic - todo
+    module::cause_todo();
+
+    // jones: expect panic - division by zero
+    module::cause_divide_by_zero();
+
+    // jones: expect panic - arithmetic overflow
+    module::cause_arithmetic_overflow();
+
+    // jones: expect panic - shift overflow
+    module::cause_shift_overflow();
 }

--- a/examples/panic/src/module/mod.rs
+++ b/examples/panic/src/module/mod.rs
@@ -8,3 +8,54 @@ pub fn cause_a_panic() {
 pub fn cause_an_unwrap() {
     let _: () = None.unwrap();
 }
+
+#[allow(clippy::unnecessary_literal_unwrap)]
+// jones: expect panic - unwrap on Err
+pub fn cause_unwrap_err() {
+    let _: () = Err("error").unwrap();
+}
+
+#[allow(clippy::assertions_on_constants)]
+// jones: expect panic - assert failed
+pub fn cause_assert() {
+    assert!(false);
+}
+
+// jones: expect panic - debug_assert failed (debug builds only)
+pub fn cause_debug_assert() {
+    debug_assert!(false);
+}
+
+// jones: expect panic - unreachable reached
+pub fn cause_unreachable() {
+    unreachable!();
+}
+
+// jones: expect panic - unimplemented reached
+pub fn cause_unimplemented() {
+    unimplemented!();
+}
+
+// jones: expect panic - todo reached
+pub fn cause_todo() {
+    todo!();
+}
+
+#[allow(unconditional_panic)]
+// jones: expect panic - division by zero
+pub fn cause_divide_by_zero() {
+    let _ = 1 / 0;
+}
+
+#[allow(arithmetic_overflow)]
+pub fn cause_arithmetic_overflow() {
+    let x: i32 = i32::MAX;
+    // jones: expect panic - arithmetic overflow (debug builds)
+    let _ = x + 1;
+}
+
+#[allow(arithmetic_overflow)]
+// jones: expect panic - shift overflow
+pub fn cause_shift_overflow() {
+    let _ = 1u32 << 33;
+}


### PR DESCRIPTION
## Summary
- Added examples for 9 additional panic types to improve test coverage
- Panic types now covered: ExplicitPanic, BoundsCheck, UnwrapNone, UnwrapErr, AssertFailed, DebugAssertFailed, Unreachable, Unimplemented, Todo, DivisionByZero, ArithmeticOverflow, ShiftOverflow, OutOfMemory

## New panic types added
- `unwrap()` on `Err` (UnwrapErr)
- `assert!(false)` (AssertFailed)
- `debug_assert!(false)` (DebugAssertFailed)
- `unreachable!()` (Unreachable)
- `unimplemented!()` (Unimplemented)
- `todo!()` (Todo)
- Division by zero (DivisionByZero)
- Arithmetic overflow (ArithmeticOverflow)
- Shift overflow (ShiftOverflow)

## Known limitations
Some panic types couldn't be added due to detection issues (tracked in #30):
- `expect()` on None/Err
- String slicing errors

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)