### PR TITLE
perf: Use binary search for function lookup (5x speedup)

### DIFF
--- a/jonesy/src/sym.rs
+++ b/jonesy/src/sym.rs
@@ -1470,19 +1470,6 @@ fn parse_function_die<R: Reader>(
     }
 }
 
-/// Find which function contains a given address
-pub fn find_function_at_address(functions: &[FunctionInfo], addr: u64) -> Option<&FunctionInfo> {
-    functions
-        .iter()
-        .find(|f| addr >= f.start_address && addr < f.end_address)
-}
-
-/// Build address-to-function lookup for efficient queries
-pub fn build_function_lookup(functions: &[FunctionInfo]) -> HashMap<u64, &FunctionInfo> {
-    // For quick lookups, you might want an interval tree in production
-    // This simple version just maps low_pc to function
-    functions.iter().map(|f| (f.start_address, f)).collect()
-}
 /// Find all functions that call a target address, with source info
 ///
 /// # Arguments


### PR DESCRIPTION
## Summary
- Replace O(n) linear search in `find_function_at_address` with O(log n) binary search using new `FunctionIndex` struct
- For flowrcli: 352K instructions × 17K functions = ~6 billion comparisons reduced to ~5 million

## Benchmark Results (flow workspace)

| Crate | Before | After | Speedup |
|-------|--------|-------|---------|
| flowc | 42.0s | 7.6s | **5.5x** |
| flowrcli | 576s (9:36) | 110s (1:50) | **5.2x** |

## Correctness
- flowc: 184 panic points, 4 files ✓
- flowrcli: 142 panic points, 15 files ✓
- All tests pass ✓

## Test plan
- [x] `cargo test -p jonesy` passes
- [x] Verified panic counts match baseline

Part of #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)