### PR TITLE
perf: Merge line table builds for 17% speedup

### DIFF
--- a/jonesy/src/sym.rs
+++ b/jonesy/src/sym.rs
@@ -312,13 +312,16 @@ impl FullLineTable {
                             file_name
                         };
 
-                        // Intern the file path
+                        // Check crate match before interning (needs &full_path)
+                        let is_crate_match = matches_crate_pattern(&full_path, crate_src_path);
+
+                        // Intern the file path (avoid double clone on cache miss)
                         let file_id = if let Some(&id) = file_to_id.get(&full_path) {
                             id
                         } else {
                             let id = file_pool.len() as u32;
                             file_pool.push(full_path.clone());
-                            file_to_id.insert(full_path.clone(), id);
+                            file_to_id.insert(full_path, id);
                             id
                         };
 
@@ -336,7 +339,7 @@ impl FullLineTable {
                         });
 
                         // Add to crate line table if matches pattern and has line
-                        if matches_crate_pattern(&full_path, crate_src_path) && line > 0 {
+                        if is_crate_match && line > 0 {
                             crate_entries.push(CrateLineEntry {
                                 address: row.address(),
                                 line,


### PR DESCRIPTION
## Summary

Merges the CrateLineTable and FullLineTable builds into a single DWARF pass, eliminating redundant iteration over the line program.

## Changes

- Add `FullLineTable::build_both()` method that builds both tables in one pass
- Update `CallGraph::build_with_debug_info()` to use the combined builder
- Both tables are still built when needed (crate filtering + source lookups)

## Benchmarks

Tested on flow workspace (5 runs each):

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Average time | 4.78s | 3.97s | **-17%** |
| Panic points | 1121 | 1121 | ✓ identical |

The optimization comes from avoiding duplicate iteration over DWARF line programs. Previously:
- `CrateLineTable::build()` → iterates all lines, filters by crate pattern
- `FullLineTable::build()` → iterates all lines again

Now both are built in a single iteration.

## Test plan

- [x] All existing tests pass
- [x] Output matches master exactly (1121 panic points on flow workspace)
- [x] Benchmarked performance improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)