### PR TITLE
feat: LSP supports fat/universal binaries

### DIFF
--- a/jonesy/src/lsp.rs
+++ b/jonesy/src/lsp.rs
@@ -1062,6 +1062,7 @@ fn analyze_single_target(
     use crate::{analyze_archive, analyze_macho};
     use goblin::mach::Mach::{Binary, Fat};
     use goblin::mach::SingleArch;
+    use goblin::mach::constants::cputype::{CPU_TYPE_ARM64, CPU_TYPE_X86_64};
 
     let binary_buffer =
         std::fs::read(target_path).map_err(|e| format!("Failed to read target: {}", e))?;
@@ -1092,9 +1093,6 @@ fn analyze_single_target(
         SymbolTable::MachO(Fat(fat)) => {
             // Fat binary - find native architecture slice and analyze it
             // Prefer slice matching the current host architecture
-            const CPU_TYPE_ARM64: u32 = 0x0100_000C;
-            const CPU_TYPE_X86_64: u32 = 0x0100_0007;
-
             let preferred_cputype = match std::env::consts::ARCH {
                 "aarch64" => Some(CPU_TYPE_ARM64),
                 "x86_64" => Some(CPU_TYPE_X86_64),


### PR DESCRIPTION
## Summary
- Handle macOS universal (fat) binaries in LSP analysis
- Previously returned "Fat binary not supported" error

## Implementation
- Extract native architecture slice (arm64 on Apple Silicon)
- Fall back to first available MachO slice if arm64 not found
- Analyze the extracted slice using existing `analyze_macho`

Note: Rust projects don't typically produce universal binaries by default, but this handles the case if they do.

Closes #90

## Test plan
- [x] Existing tests pass
- [ ] Manual test with a fat binary (if available)

🤖 Generated with [Claude Code](https://claude.com/claude-code)