### PR TITLE
refactor: Remove unused parameters from analyze functions

### DIFF
--- a/jonesy/src/lsp.rs
+++ b/jonesy/src/lsp.rs
@@ -1085,7 +1085,6 @@ fn analyze_single_target(
                 Some(src_filter),
                 false, // show_timings
                 &config,
-                Some(workspace_root),
                 &output,
             );
             Ok(result.code_points)
@@ -1130,7 +1129,6 @@ fn analyze_single_target(
                         Some(src_filter),
                         false, // show_timings
                         &config,
-                        Some(workspace_root),
                         &output,
                     );
                     Ok(result.code_points)
@@ -1142,11 +1140,9 @@ fn analyze_single_target(
             let result = analyze_archive(
                 &archive,
                 &binary_buffer,
-                target_path,
                 Some(src_filter),
                 false, // show_timings
                 &config,
-                Some(workspace_root),
                 &output,
             );
             Ok(result.code_points)

--- a/jonesy/src/main.rs
+++ b/jonesy/src/main.rs
@@ -164,7 +164,6 @@ fn main() -> Result<(), Box<dyn Error>> {
                     crate_src_path.as_deref(),
                     parsed_args.show_timings,
                     &config,
-                    project_root.as_deref(),
                     &parsed_args.output,
                 );
                 total_summary.add(&result.summary);
@@ -192,11 +191,9 @@ fn main() -> Result<(), Box<dyn Error>> {
                 let result = analyze_archive(
                     &archive,
                     &binary_buffer,
-                    &binary_path,
                     crate_src_path.as_deref(),
                     parsed_args.show_timings,
                     &config,
-                    project_root.as_deref(),
                     &parsed_args.output,
                 );
                 total_summary.add(&result.summary);
@@ -312,7 +309,6 @@ pub(crate) fn analyze_macho(
     crate_src_path: Option<&str>,
     show_timings: bool,
     config: &Config,
-    _project_root: Option<&Path>,
     output: &OutputFormat,
 ) -> BinaryAnalysisResult {
     let show_progress = output.show_progress();
@@ -515,18 +511,14 @@ fn is_stdlib_function(name: &str) -> bool {
 
 /// Analyze an archive (rlib/staticlib) for panic points using relocation-based call graph.
 /// This works for library-only crates that don't have binary entry points.
-#[allow(clippy::too_many_arguments)]
 pub(crate) fn analyze_archive(
     archive: &goblin::archive::Archive,
     buffer: &[u8],
-    _binary_path: &Path,
     crate_src_path: Option<&str>,
     show_timings: bool,
     config: &Config,
-    _project_root: Option<&Path>,
     output: &OutputFormat,
 ) -> BinaryAnalysisResult {
-    // See issue #56 for planned enhancements to these unused parameters
     use std::collections::HashSet;
 
     // Helper to check if a file path is within the crate/workspace scope
@@ -866,7 +858,6 @@ fn analyze_workspace(members: &[WorkspaceMember], args: &Args) -> Result<(), Box
                         Some(&workspace_src_path),
                         args.show_timings,
                         &config,
-                        Some(workspace_root.as_path()),
                         &args.output,
                     ),
                     SymbolTable::MachO(Fat(_)) => {
@@ -876,11 +867,9 @@ fn analyze_workspace(members: &[WorkspaceMember], args: &Args) -> Result<(), Box
                     SymbolTable::Archive(archive) => analyze_archive(
                         &archive,
                         &binary_buffer,
-                        &binary_path,
                         Some(&workspace_src_path),
                         args.show_timings,
                         &config,
-                        Some(workspace_root.as_path()),
                         &args.output,
                     ),
                 };


### PR DESCRIPTION
## Summary

Closes #56 - The unused parameters in `analyze_macho` and `analyze_archive` have been removed.

### Background

Issue #56 originally tracked implementing features for unused parameters. However, these features were already implemented through other means:

| Original Parameter | Intended Use | Current Implementation |
|-------------------|--------------|------------------------|
| `_no_hyperlinks` | Terminal hyperlinks | ✅ Via `OutputFormat::use_hyperlinks()` |
| `_config` | Allow/deny filtering | ✅ Via `config` parameter (already used) |
| `_project_root` | Relative path display | Not needed - paths are absolute |
| `_binary_path` (archive only) | Path display | Not needed - shown in "Processing X" |

### Changes

- Removed `_project_root` parameter from `analyze_macho` (7 → 6 params)
- Removed `_project_root` and `_binary_path` parameters from `analyze_archive` (8 → 6 params)
- Removed `#[allow(clippy::too_many_arguments)]` from `analyze_archive`
- Updated all call sites in `main.rs` and `lsp.rs`

### Test Plan

- [x] `cargo fmt` passes
- [x] `cargo clippy` passes  
- [x] All unit tests pass (19)
- [x] All integration tests pass (13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)