### PR TITLE
feat(lsp): Re-publish diagnostics to files opened before analysis

### DIFF
--- a/jonesy/src/lsp.rs
+++ b/jonesy/src/lsp.rs
@@ -513,24 +513,27 @@ impl JonesyLspServer {
             .await;
 
         // Re-publish diagnostics to files that were opened before/during analysis
-        let state = self.state.read().await;
-        let opened_files: Vec<Url> = state.opened_files.iter().cloned().collect();
-        drop(state);
-
-        for uri in opened_files {
+        // Snapshot all data while holding the lock once, then publish outside the lock
+        let republish: Vec<(Url, Vec<Diagnostic>)> = {
             let state = self.state.read().await;
-            if let Some(points) = state.panic_points.get(&uri) {
-                let diagnostics: Vec<Diagnostic> = points
-                    .iter()
-                    .map(Self::code_point_to_diagnostic)
-                    .collect();
-                drop(state);
+            state
+                .opened_files
+                .iter()
+                .filter_map(|uri| {
+                    state.panic_points.get(uri).map(|points| {
+                        let diagnostics =
+                            points.iter().map(Self::code_point_to_diagnostic).collect();
+                        (uri.clone(), diagnostics)
+                    })
+                })
+                .collect()
+        };
 
-                if !diagnostics.is_empty() {
-                    self.client
-                        .publish_diagnostics(uri, diagnostics, None)
-                        .await;
-                }
+        for (uri, diagnostics) in republish {
+            if !diagnostics.is_empty() {
+                self.client
+                    .publish_diagnostics(uri, diagnostics, None)
+                    .await;
             }
         }
         true
@@ -819,10 +822,8 @@ impl LanguageServer for JonesyLspServer {
         // If we have cached diagnostics for this file, publish them now
         let state = self.state.read().await;
         if let Some(points) = state.panic_points.get(&uri) {
-            let diagnostics: Vec<Diagnostic> = points
-                .iter()
-                .map(Self::code_point_to_diagnostic)
-                .collect();
+            let diagnostics: Vec<Diagnostic> =
+                points.iter().map(Self::code_point_to_diagnostic).collect();
             drop(state); // Release lock before async call
 
             if !diagnostics.is_empty() {
@@ -839,7 +840,11 @@ impl LanguageServer for JonesyLspServer {
 
     async fn did_close(&self, params: DidCloseTextDocumentParams) {
         // Remove from opened files tracking
-        self.state.write().await.opened_files.remove(&params.text_document.uri);
+        self.state
+            .write()
+            .await
+            .opened_files
+            .remove(&params.text_document.uri);
     }
 
     async fn did_save(&self, _params: DidSaveTextDocumentParams) {


### PR DESCRIPTION
## Summary

Fix timing issue where diagnostics don't appear for files that were already open when analysis ran.

## Changes

- Track opened files in `ServerState.opened_files`
- Re-publish diagnostics to all opened files after analysis completes
- Publish cached diagnostics immediately when a file is opened via `did_open`

## Problem

When a user opens a file before or during analysis, the LSP publishes diagnostics to that file URI, but some IDEs (like RustRover with LSP4IJ) don't pick them up until the file is closed and reopened.

## Solution

After analysis completes, iterate through all tracked opened files and re-publish their diagnostics. Also publish cached diagnostics immediately in `did_open` handler.

## Test Plan

- [x] Cargo tests pass
- [ ] Manual test: Open file in IDE, trigger analysis, verify diagnostics appear without reopening

Related: #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)