### PR TITLE
feat: Distinguish direct vs indirect panics in help messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,49 @@ Summary:
   Panic points: 0 in 0 file(s)
 ```
 
+### Direct vs Indirect Panics
+
+Jonesy distinguishes between **direct** and **indirect** panics, providing different suggestions for each:
+
+**Direct panic** — Your code directly calls a panic-triggering function:
+
+```rust
+let value = some_option.unwrap();  // Direct call to unwrap()
+```
+
+```
+--> src/main.rs:42:1 [JP006: unwrap() on None]
+    = help: Use if let, match, unwrap_or, or ? operator instead
+```
+
+**Indirect panic** — Your code calls a function that may panic internally:
+
+```rust
+let mut builder = Builder::from_default_env();
+builder.filter_level(level).init();  // init() internally calls unwrap()
+```
+
+```
+--> src/main.rs:70:1 [JP007: unwrap() on Err]
+    = help: This calls a function that may call unwrap(). Consider a fallible alternative (e.g., try_*)
+```
+
+There's no visible `unwrap()` on line 70, but this is correct! The `env_logger::Builder::init()` method internally calls `try_init().unwrap()`. Jonesy identifies that calling `init()` can lead to a panic, even though the `unwrap()` is inside another function.
+
+For indirect panics, the suggestion recommends using a fallible alternative when available:
+
+```rust
+builder.filter_level(level).try_init().ok();  // Won't panic
+```
+
+Common fallible alternatives:
+- `Mutex::lock()` → `Mutex::try_lock()`
+- `Vec::reserve()` → `Vec::try_reserve()`
+- `env_logger::init()` → `env_logger::try_init()`
+- `thread::spawn().join().unwrap()` → handle the `Result`
+
+Jonesy helps you find these hidden panic paths so you can decide whether to use fallible alternatives or accept the panic risk.
+
 ## Requirements
 
 - macOS with ARM64 (Apple Silicon)—currently the only supported platform

--- a/jonesy/src/call_tree.rs
+++ b/jonesy/src/call_tree.rs
@@ -180,21 +180,60 @@ pub struct CrateCodePoint {
     pub causes: HashSet<PanicCause>,
     /// Code points that this one calls (closer to panic in the call chain)
     pub children: Vec<CrateCodePoint>,
+    /// Whether this code point directly calls a panic-triggering function (e.g., unwrap, expect)
+    /// vs calling another function that eventually panics
+    pub is_direct_panic: bool,
 }
 
 /// Key for identifying a code point: (file, line)
 type CodePointKey = (String, u32);
 
-/// Info stored for each code point: (function name, column, set of causes, set of child keys)
+/// Info stored for each code point: (function name, column, set of causes, set of child keys, is_direct_panic)
 type CodePointInfo = (
     String,
     Option<u32>,
     HashSet<PanicCause>,
     HashSet<CodePointKey>,
+    bool, // is_direct_panic
 );
 
 /// Map of code points: key -> info
 type CodePointMap = HashMap<CodePointKey, CodePointInfo>;
+
+/// Check if a function name represents a panic-triggering function.
+/// These are functions that directly cause a panic (unwrap, expect, panic!, etc.)
+/// as opposed to functions that call other functions that eventually panic.
+fn is_panic_triggering_function(func_name: &str) -> bool {
+    // Unwrap/expect variants
+    func_name.contains("unwrap_failed")
+        || func_name.contains("expect_failed")
+        // Direct unwrap/expect calls (before they reach _failed)
+        || (func_name.contains("unwrap") && !func_name.contains("unwrap_or"))
+        || (func_name.contains("expect") && func_name.contains("Option"))
+        || (func_name.contains("expect") && func_name.contains("Result"))
+        // Panic functions
+        || func_name.contains("panic_fmt")
+        || func_name.contains("panic_display")
+        || func_name.contains("panic_bounds_check")
+        || func_name.contains("panic_const_")
+        || func_name.contains("panic_in_cleanup")
+        || func_name.contains("panic_cannot_unwind")
+        || func_name.contains("panic_nounwind")
+        || func_name.contains("panic_misaligned_pointer")
+        || func_name.contains("panic_invalid_enum")
+        // Assert
+        || func_name.contains("assert_failed")
+        // Capacity/allocation
+        || func_name.contains("capacity_overflow")
+        || func_name.contains("handle_alloc_error")
+        // String/slice errors
+        || func_name.contains("slice_error_fail")
+        || func_name.contains("str_index_overflow_fail")
+        // Index trait - direct bounds check
+        || func_name.starts_with("index<")
+        || func_name.contains("::index<")
+        || func_name.contains("Index::index")
+}
 
 /// Collect crate code points with hierarchy.
 /// Returns a list of "root" code points (entry points) with their children.
@@ -206,12 +245,12 @@ pub fn collect_crate_code_points_hierarchical(
     // Map: (file, line) -> (name, cause, set of child keys)
     let mut points: CodePointMap = CodePointMap::new();
 
-    collect_crate_relationships(node, crate_src_path, &mut points, None, None);
+    collect_crate_relationships(node, crate_src_path, &mut points, None, None, None);
 
     // Find roots: points that are not in any other point's children
     let all_children: HashSet<(String, u32)> = points
         .values()
-        .flat_map(|(_, _, _, children)| children.iter().cloned())
+        .flat_map(|(_, _, _, children, _)| children.iter().cloned())
         .collect();
 
     let mut roots: Vec<CodePointKey> = points
@@ -237,7 +276,7 @@ pub fn collect_crate_code_points_hierarchical(
             return None;
         }
 
-        let (name, column, causes, child_keys_set) = points.get(key)?;
+        let (name, column, causes, child_keys_set, is_direct_panic) = points.get(key)?;
         // Sort child keys for deterministic output
         let mut child_keys: Vec<_> = child_keys_set.iter().cloned().collect();
         child_keys.sort();
@@ -255,6 +294,7 @@ pub fn collect_crate_code_points_hierarchical(
             column: *column,
             causes: causes.clone(),
             children,
+            is_direct_panic: *is_direct_panic,
         })
     }
 
@@ -273,12 +313,15 @@ pub fn collect_crate_code_points_hierarchical(
 /// For our output hierarchy: B is the parent (entry point), A is the child (closer to panic).
 ///
 /// Also detects panic causes from function names in the call path.
+/// Tracks `immediate_callee` to determine if panic is direct (calling unwrap/expect directly)
+/// or indirect (calling a function that eventually panics).
 fn collect_crate_relationships(
     node: &CallTreeNode,
     crate_src_path: &str,
     points: &mut CodePointMap,
     child_crate_key: Option<CodePointKey>,
     current_cause: Option<PanicCause>,
+    immediate_callee: Option<&str>, // Name of function this node calls (toward panic)
 ) {
     // Try to detect panic cause from this node's function name and file path
     let detected_cause = detect_panic_cause(&node.name, node.file.as_deref()).or(current_cause);
@@ -299,6 +342,11 @@ fn collect_crate_relationships(
     };
 
     if let Some(key) = &node_key {
+        // Determine if this is a direct panic (immediate callee is a panic-triggering function)
+        let is_direct = immediate_callee
+            .map(is_panic_triggering_function)
+            .unwrap_or(false);
+
         // Ensure this point exists in the map and accumulate all causes
         let entry = points.entry(key.clone()).or_insert_with(|| {
             (
@@ -306,8 +354,15 @@ fn collect_crate_relationships(
                 node.column,
                 HashSet::new(),
                 HashSet::new(),
+                is_direct,
             )
         });
+
+        // Update is_direct_panic: true if ANY path through this point is direct
+        // (conservative: if one path is direct, user could be calling directly)
+        if is_direct {
+            entry.4 = true;
+        }
 
         // Add this path's cause to the set of causes (if detected)
         if let Some(cause) = &detected_cause {
@@ -331,6 +386,7 @@ fn collect_crate_relationships(
             points,
             next_child.clone(),
             detected_cause.clone(),
+            Some(&node.name), // Current node is the callee for the caller
         );
     }
 }

--- a/jonesy/src/html_output.rs
+++ b/jonesy/src/html_output.rs
@@ -307,7 +307,7 @@ fn render_panic_point(
 
     // Cause details
     if let Some(c) = cause {
-        let suggestion = c.suggestion();
+        let suggestion = c.suggestion(point.is_direct_panic);
         let warning = c.release_warning();
         if !suggestion.is_empty() || warning.is_some() {
             html.push_str(&format!("{}    <div class=\"cause-details\">\n", indent));

--- a/jonesy/src/json_output.rs
+++ b/jonesy/src/json_output.rs
@@ -79,7 +79,7 @@ fn code_point_to_json(point: &CrateCodePoint, project_root: &str, include_childr
         let mut causes: Vec<_> = point.causes.iter().collect();
         causes.sort_by_key(|c| c.description());
         causes.first().map(|c| {
-            let suggestion = c.suggestion();
+            let suggestion = c.suggestion(point.is_direct_panic);
             let mut cause_obj = json!({
                 "code": c.error_code(),
                 "type": c.id(),

--- a/jonesy/src/lsp.rs
+++ b/jonesy/src/lsp.rs
@@ -65,7 +65,7 @@ impl JonesyLspServer {
             if let Some(cause) = point.causes.iter().next() {
                 (
                     format!("panic point: {}", cause.description()),
-                    Some(cause.suggestion().to_string()),
+                    Some(cause.suggestion(point.is_direct_panic).to_string()),
                     Some(cause.error_code().to_string()),
                     Url::parse(&cause.docs_url()).ok(),
                 )

--- a/jonesy/src/main.rs
+++ b/jonesy/src/main.rs
@@ -699,7 +699,8 @@ pub(crate) fn analyze_archive(
                 line: caller.line,
                 column: caller.column,
                 causes,
-                children: Vec::new(), // Archives don't have call tree hierarchy
+                children: Vec::new(),  // Archives don't have call tree hierarchy
+                is_direct_panic: true, // Archive analysis detects direct panic calls
             }
         })
         .collect();

--- a/jonesy/src/panic_cause.rs
+++ b/jonesy/src/panic_cause.rs
@@ -168,8 +168,24 @@ impl PanicCause {
         }
     }
 
-    /// Get a suggestion for how to avoid this panic
-    pub fn suggestion(&self) -> &'static str {
+    /// Get a suggestion for how to avoid this panic.
+    ///
+    /// # Arguments
+    /// * `is_direct` - Whether the panic is direct (user code calls unwrap/expect directly)
+    ///   or indirect (user code calls a function that eventually panics internally).
+    ///
+    /// For indirect panics, suggestions recommend using fallible alternatives when available,
+    /// since the user cannot simply replace the call with `if let` or `match`.
+    pub fn suggestion(&self, is_direct: bool) -> &'static str {
+        if is_direct {
+            self.direct_suggestion()
+        } else {
+            self.indirect_suggestion()
+        }
+    }
+
+    /// Suggestion for direct panics (user code directly calls panic-triggering function)
+    fn direct_suggestion(&self) -> &'static str {
         match self {
             PanicCause::ExplicitPanic => "Review if panic is intentional or add error handling",
             PanicCause::BoundsCheck => "Use .get() for safe access or validate index before use",
@@ -213,6 +229,65 @@ impl PanicCause {
             }
             PanicCause::Unknown => {
                 "Jonesy detected a panic path but couldn't identify the cause. Use --tree to investigate"
+            }
+        }
+    }
+
+    /// Suggestion for indirect panics (user code calls a function that may panic internally)
+    fn indirect_suggestion(&self) -> &'static str {
+        match self {
+            PanicCause::ExplicitPanic => {
+                "This calls a function that may panic. Review the called function or handle errors"
+            }
+            PanicCause::BoundsCheck => {
+                "This calls a function that may panic on bounds check. Validate inputs or use a fallible alternative"
+            }
+            PanicCause::ArithmeticOverflow(_) => {
+                "This calls a function that may overflow. Validate inputs or use checked arithmetic"
+            }
+            PanicCause::ShiftOverflow(_) => {
+                "This calls a function that may overflow on shift. Validate inputs"
+            }
+            PanicCause::DivisionByZero => {
+                "This calls a function that may divide by zero. Validate inputs"
+            }
+            PanicCause::UnwrapNone | PanicCause::UnwrapErr => {
+                "This calls a function that may call unwrap(). Consider a fallible alternative (e.g., try_*)"
+            }
+            PanicCause::ExpectNone | PanicCause::ExpectErr => {
+                "This calls a function that may call expect(). Consider a fallible alternative (e.g., try_*)"
+            }
+            PanicCause::AssertFailed => {
+                "This calls a function with an assertion. Review preconditions"
+            }
+            PanicCause::DebugAssertFailed => {
+                "This calls a function with a debug assertion. Review preconditions"
+            }
+            PanicCause::Unreachable => {
+                "This calls a function that may reach unreachable code. Review control flow"
+            }
+            PanicCause::Unimplemented => "This calls a function with unimplemented!() code paths",
+            PanicCause::Todo => "This calls a function with todo!() code paths",
+            PanicCause::PanicInDrop => "This calls a function that may panic during drop",
+            PanicCause::CannotUnwind => {
+                "This calls a function that may panic in a no-unwind context"
+            }
+            PanicCause::FormattingError => "This calls a function that may panic during formatting",
+            PanicCause::CapacityOverflow => {
+                "This calls a function that may overflow capacity. Consider fallible allocation (try_reserve)"
+            }
+            PanicCause::OutOfMemory => "This calls a function that may fail to allocate memory",
+            PanicCause::StringSliceError => {
+                "This calls a function that may fail on string/slice operations"
+            }
+            PanicCause::InvalidEnum => {
+                "This calls a function that may encounter an invalid enum discriminant"
+            }
+            PanicCause::MisalignedPointer => {
+                "This calls a function that may dereference a misaligned pointer"
+            }
+            PanicCause::Unknown => {
+                "This calls a function that may panic. Use --tree to investigate the call chain"
             }
         }
     }

--- a/jonesy/src/text_output.rs
+++ b/jonesy/src/text_output.rs
@@ -156,7 +156,7 @@ fn print_flat_point(point: &CrateCodePoint, project_root: Option<&Path>) {
 
     if is_leaf {
         if let Some(cause) = primary_cause {
-            let suggestion = cause.suggestion();
+            let suggestion = cause.suggestion(point.is_direct_panic);
             if !suggestion.is_empty() {
                 println!("     = help: {}", suggestion);
             }
@@ -196,7 +196,7 @@ fn print_flat_child(point: &CrateCodePoint, project_root: Option<&Path>, indent:
 
     if is_leaf {
         if let Some(cause) = primary_cause {
-            let suggestion = cause.suggestion();
+            let suggestion = cause.suggestion(point.is_direct_panic);
             if !suggestion.is_empty() {
                 println!("{}     = help: {}", indent, suggestion);
             }
@@ -271,7 +271,7 @@ fn print_file_entry(
 
     if is_leaf {
         if let Some(cause) = primary_cause {
-            let suggestion = cause.suggestion();
+            let suggestion = cause.suggestion(point.is_direct_panic);
             if !suggestion.is_empty() {
                 let help_prefix = if is_root_level { "     " } else { prefix };
                 println!("{}    = help: {}", help_prefix, suggestion);
@@ -371,7 +371,7 @@ fn print_crate_point(
 
     if is_leaf {
         if let Some(cause) = primary_cause {
-            let suggestion = cause.suggestion();
+            let suggestion = cause.suggestion(point.is_direct_panic);
             if !suggestion.is_empty() {
                 let help_prefix = if is_root { "     " } else { prefix };
                 println!("{}    = help: {}", help_prefix, suggestion);


### PR DESCRIPTION
## Summary

- Adds context-aware suggestions based on whether the panic is direct or indirect
- Direct panics: user code calls unwrap/expect directly → "Use if let, match, or ?"
- Indirect panics: user code calls a function that may panic → "Consider a fallible alternative (try_*)"

## Changes

- Add `is_direct_panic` field to `CrateCodePoint`
- Add `is_panic_triggering_function()` helper to detect direct panic calls
- Track immediate callee in `collect_crate_relationships`
- `PanicCause::suggestion()` now takes `is_direct` parameter
- Update all output formats (text, JSON, HTML, LSP)
- Document "Direct vs Indirect Panics" in README

## Example Output

**Direct panic** (user code calls unwrap directly):
```
--> src/main.rs:42:1 [JP006: unwrap() on None]
    = help: Use if let, match, unwrap_or, or ? operator instead
```

**Indirect panic** (user code calls a function that may panic):
```
--> src/main.rs:70:1 [JP007: unwrap() on Err]
    = help: This calls a function that may call unwrap(). Consider a fallible alternative (e.g., try_*)
```

## Test plan

- [x] All existing tests pass
- [x] Tested on flow/flowrex binary - shows different messages for direct vs indirect

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)