### PR TITLE
fix: Bump to v0.6.1 and fix example workflow

### DIFF
--- a/.github/workflows/jonesy-example.yml
+++ b/.github/workflows/jonesy-example.yml
@@ -39,10 +39,11 @@ jobs:
         run: cargo build
 
       - name: Run jonesy analysis
+        id: jonesy
         uses: andrewdavidmackenzie/jonesy@v1
         with:
           fail-on-panic: false  # Set to true to fail the build if panics found
 
       # The action outputs the panic count for use in subsequent steps
-      # - name: Check panic count
-      #   run: echo "Found ${{ steps.jonesy.outputs.panic-count }} panic points"
+      - name: Check panic count
+        run: echo "Found ${{ steps.jonesy.outputs.panic-count }} panic points"

--- a/jonesy/Cargo.toml
+++ b/jonesy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jonesy"
 description = "Jonesy is here to help you not panic!"
-version = "0.6.0"
+version = "0.6.1"
 edition = "2024"
 rust-version = "1.85"
 authors = [" Andrew Mackenzie andrew@mackenzie-serres.net"]


### PR DESCRIPTION
## Summary
- v0.6.0 was published before PR #143 (single-crate dependency filtering)
- Need v0.6.1 with the fix
- Also fixes example workflow:
  - Add `id: jonesy` so `steps.jonesy.outputs.panic-count` works
  - Uncomment the check panic count step

After merging:
1. `cargo publish -p jonesy`
2. Update v1 tag: `git tag -f v1 && git push -f origin v1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)