### PR TITLE
fix: Filter phantom async panic points (closes #165)

### DIFF
--- a/jonesy/src/call_tree.rs
+++ b/jonesy/src/call_tree.rs
@@ -613,7 +613,11 @@ fn filter_phantom_async_panics(points: &mut Vec<CrateCodePoint>) {
 /// a phantom when it has no children and Unknown cause (indicates empty
 /// or very simple async function where only generated drop code can panic).
 fn is_phantom_async_function(name: &str) -> bool {
-    name.starts_with("{async_fn#")
+    // Handle both simple names like "{async_fn#0}" and
+    // fully qualified names like "crate::mod::foo::{async_fn#0}"
+    name.rsplit("::")
+        .next()
+        .is_some_and(|tail| tail.starts_with("{async_fn#"))
 }
 
 /// Filter out code points whose causes are ALL allowed (not denied) by config or inline comments.


### PR DESCRIPTION
## Summary

Empty async functions like `async fn empty() {}` were incorrectly reported as panic points with unknown cause. This fixes it by filtering phantom async panics.

### The Problem

Rust compiles async functions into state machines with `drop_in_place` handlers. These handlers have panic paths (e.g., `panic_misaligned_pointer_dereference`) that can never actually be triggered by user code but were being reported by jonesy.

### The Fix

Add a filter in `call_tree.rs` that removes phantom async panic points matching:
1. Function name matches `{async_fn#N}` pattern (generated state machine)
2. Only cause is Unknown (no specific panic identified)
3. No children (no real panic-inducing code in call chain)

This combination strongly indicates phantom panics from generated drop handlers, not real user code that can panic.

### Why It's Reliable

- If the async function had real panic-inducing code, there would be children
- If the panic cause could be identified from the call chain, it wouldn't be Unknown
- We only filter `{async_fn#N}` patterns, not `{async_block#N}` or `{closure#N}`

## Test plan

- [x] Verified empty async functions in meshchat (conversation.rs:69, device.rs:238, device_list.rs:75) are no longer reported
- [x] Verified legitimate async panic points (36 remaining) are still reported
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)