### PR TITLE
fix: Auto-update v1 tag on new releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,10 +66,21 @@ jobs:
             dist/jonesy-aarch64-apple-darwin.tar.gz \
             dist/jonesy-macos-arm64
 
+      - name: Update v1 tag for GitHub Action users
+        if: steps.check_release.outputs.exists == 'false'
+        run: |
+          # Update the v1 tag to point to this release
+          # This ensures users of andrewdavidmackenzie/jonesy@v1 get the latest version
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -f v1
+          git push origin v1 --force
+
       - name: Release summary
         if: steps.check_release.outputs.exists == 'false'
         run: |
           echo "::notice::Created release v${{ steps.version.outputs.version }}"
+          echo "::notice::Updated v1 tag for GitHub Action users"
           echo ""
           echo "Install with cargo-binstall:"
           echo "  cargo binstall jonesy"


### PR DESCRIPTION
## Summary
- Add step to release workflow that updates the `v1` tag to point to each new release
- Ensures users of `andrewdavidmackenzie/jonesy@v1` always get the latest version

## Root Cause
The `v1` tag was created once and never updated. When new releases were made (v0.7.x), the v1 tag still pointed to the old v0.6.1 commit, causing:
1. Panic count wraparound (260 mod 256 = 4) - old code used exit code directly
2. Missing PR comment feature - didn't exist in old version

## Fix
The release workflow now force-updates the `v1` tag after creating each release.

Fixes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)