### PR TITLE
fix: Fix PR comment summary showing duplicate values

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -70,13 +70,18 @@ runs:
         echo "$output"
 
         # Also capture JSON output for PR comment
+        # Note: jonesy exits non-zero when panics are found, so we ignore the exit code
         if [ -n "${{ inputs.binary }}" ]; then
-          json_output=$(jonesy --format json ${{ inputs.extra-args }} "${{ inputs.binary }}" 2>/dev/null || echo '{}')
+          json_output=$(jonesy --format json ${{ inputs.extra-args }} "${{ inputs.binary }}" 2>/dev/null) || true
         else
-          json_output=$(jonesy --format json ${{ inputs.extra-args }} 2>/dev/null || echo '{}')
+          json_output=$(jonesy --format json ${{ inputs.extra-args }} 2>/dev/null) || true
         fi
-        # Save JSON to file for next step
-        echo "$json_output" > /tmp/jonesy-output.json
+        # Save JSON to file for next step (use empty object if no output)
+        if [ -n "$json_output" ]; then
+          echo "$json_output" > /tmp/jonesy-output.json
+        else
+          echo '{}' > /tmp/jonesy-output.json
+        fi
 
         # Parse panic count from output: "Panic points: X in Y file(s)"
         # This handles counts > 255 which would wrap in exit codes


### PR DESCRIPTION
## Problem
The PR comment summary was showing malformed text like:
```
Found 262
0 panic point(s) in 17
0 file(s)
```

## Root Cause
The JSON capture used `|| echo '{}'` to handle errors:
```bash
json_output=$(jonesy --format json ... || echo '{}')
```

Since jonesy exits non-zero when panics are found, this appended an empty `{}` to the output, creating two JSON objects:
```json
{"summary":{"panic_points":262,"files_affected":17},...}
{}
```

When jq processed both objects, it output two values per query (`262\n0`), which got interpolated into the markdown.

## Fix
Use `|| true` to ignore the exit code, then check if output is empty before writing to file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)