### PR TITLE
fix: Demangle Rust symbols in function names

### DIFF
--- a/jonesy/src/call_tree.rs
+++ b/jonesy/src/call_tree.rs
@@ -331,14 +331,22 @@ fn extract_simple_function_name(full_name: &str) -> String {
         if trimmed.is_empty() {
             continue;
         }
-        if trimmed.starts_with('h') && trimmed.len() > 1 && trimmed[1..].chars().all(|c| c.is_ascii_hexdigit()) {
+        if trimmed.starts_with('h')
+            && trimmed.len() > 1
+            && trimmed[1..].chars().all(|c| c.is_ascii_hexdigit())
+        {
             continue;
         }
         return trimmed.to_string();
     }
 
     // Fallback: return the last non-empty segment
-    cleaned.rsplit("::").find(|s| !s.is_empty()).unwrap_or(&cleaned).trim().to_string()
+    cleaned
+        .rsplit("::")
+        .find(|s| !s.is_empty())
+        .unwrap_or(&cleaned)
+        .trim()
+        .to_string()
 }
 
 /// Collect crate code points with hierarchy.
@@ -961,7 +969,10 @@ mod tests {
         // Real mangled Rust symbol for std::collections::hash::set::HashSet<T>::new
         let mangled = "_ZN3std11collections4hash3set16HashSet$LT$T$GT$3new17ha7a7fdf7dbcd659dE";
         let result = extract_simple_function_name(mangled);
-        assert_eq!(result, "new", "Should demangle and extract 'new' from HashSet::new");
+        assert_eq!(
+            result, "new",
+            "Should demangle and extract 'new' from HashSet::new"
+        );
     }
 
     #[test]
@@ -975,10 +986,7 @@ mod tests {
             extract_simple_function_name("HashMap<K, V>::insert"),
             "insert"
         );
-        assert_eq!(
-            extract_simple_function_name("Vec<Option<T>>::push"),
-            "push"
-        );
+        assert_eq!(extract_simple_function_name("Vec<Option<T>>::push"), "push");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix mangled symbols like `_ZN3std11collections4hash3set16HashSet$LT$T$GT$3new17h...` being shown in LSP output
- Now correctly shows `new` instead of the mangled name

## Changes
- Use `rustc_demangle` to demangle symbols before extracting simple names
- Handle nested generics by removing all `<...>` content while preserving the rest
- Skip Rust hash suffixes (like `h1234abcd...`) that appear at the end of symbols

## Tests Added
Added 6 unit tests for `extract_simple_function_name` to prevent this regression:
- `test_extract_simple_function_name_mangled_rust_symbol` - tests real mangled symbol
- `test_extract_simple_function_name_with_nested_generics` - tests `HashSet<T>::new`
- `test_extract_simple_function_name_no_mangled_output` - ensures NO mangled output ever
- `test_extract_simple_function_name_already_demangled` - tests normal paths
- `test_extract_simple_function_name_with_generics` - tests simple generics
- `test_extract_simple_function_name_simple` - tests simple names

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass
- [x] Verify in meshchat that config.rs:162 shows `new` instead of mangled name

Fixes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)