### PR TITLE
chore: Bump version to 0.7.7

### DIFF
--- a/jonesy/Cargo.toml
+++ b/jonesy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jonesy"
 description = "Jonesy is here to help you not panic!"
-version = "0.7.6"
+version = "0.7.7"
 edition = "2024"
 rust-version = "1.85"
 authors = [" Andrew Mackenzie andrew@mackenzie-serres.net"]


### PR DESCRIPTION
## Summary
- Bump version to 0.7.7 for release with demangled symbol names fix (#186)

## Test plan
- CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)