### PR TITLE
fix: Phase 6 - Fix ELF dylib and rlib detection issues

### DIFF
--- a/PHASE6_PLAN.md
+++ b/PHASE6_PLAN.md
@@ -79,8 +79,8 @@ cargo test --release test_dylib_example
 cargo test --release test_rlib_example
 
 # Check what jonesy detects
-cd examples/dylib && ../../target/release/jonesy --lib
-cd examples/rlib && ../../target/release/jonesy --lib
+(cd examples/dylib && ../../target/release/jonesy --lib)
+(cd examples/rlib && ../../target/release/jonesy --lib)
 
 # Run all tests
 make test

--- a/PHASE6_PLAN.md
+++ b/PHASE6_PLAN.md
@@ -1,0 +1,93 @@
+# Phase 6: Fix Remaining ELF Detection Issues
+
+## Objective
+
+Fix the two remaining test failures on Linux aarch64 that were ignored in Phase 5:
+
+1. **test_dylib_example** - 42 missing panics (ALL panics missing)
+2. **test_rlib_example** - 2 missing panics (conditional value tracking)
+
+## Current Status
+
+Both tests are currently marked with `#[cfg_attr(target_os = "linux", ignore)]` to allow CI to pass. See PHASE6_HANDOFF.md for detailed analysis.
+
+## Issue 1: test_dylib_example (42 missing panics)
+
+**Problem:** Entry point analysis finds "2 entry points (panic + abort)" but no panic paths are traced.
+
+**File Type:** `target/debug/libdylib_example.so: ELF 64-bit LSB shared object, ARM aarch64`
+
+**Hypothesis:**
+- Entry points are detected correctly
+- But panic path tracing doesn't work for ELF shared objects (.so files)
+- This is dylib-specific (cdylib, rlib, staticlib all work)
+- Likely issue in `analyze_binary_target()` vs `analyze_archive()` code paths
+
+**Investigation Plan:**
+1. Compare entry point analysis between ELF binary and ELF shared object
+2. Check if the issue is in entry point detection or panic path tracing
+3. Debug what happens after "Found 2 entry points" message
+4. Compare with how macOS dylib works (if it works there)
+
+## Issue 2: test_rlib_example (2 missing panics)
+
+**Problem:** Missing 2 unwrap calls that use `rand::Rng` for conditional values
+
+**Missing Lines:**
+- `examples/rlib/src/module/mod.rs:10` - `opt.unwrap()` after conditional Some/None
+- `examples/rlib/src/module/mod.rs:22` - `result.unwrap()` after conditional Ok/Err
+
+**Working Cases:**
+- Direct `None.expect()` - ✅ detected
+- Direct `Some(x).unwrap()` - ✅ detected
+- All other unwrap/expect calls - ✅ detected
+
+**Key Difference:**
+```rust
+// This WORKS (detected):
+let _: () = None.expect("expected a value");
+
+// This FAILS (missing):
+let opt: Option<i32> = if rng.random_bool(0.0) { Some(42) } else { None };
+opt.unwrap();
+```
+
+**Hypothesis:**
+- Panic path tracking doesn't follow through rand conditional logic
+- Might be a line number mapping issue (marker on line 10, actual panic on line 11)
+- Or the unwrap path is missed because the Option value comes from a conditional
+
+**Investigation Plan:**
+1. Check if the issue is line number alignment
+2. Test with simpler conditional: `let opt = if true { None } else { Some(42) };`
+3. Debug why rand-based conditionals break detection
+4. Check if it's specific to the rand library or any runtime-conditional values
+
+## Success Criteria
+
+- [ ] test_dylib_example passes (42 panics detected)
+- [ ] test_rlib_example passes (2 missing unwraps detected)
+- [ ] Remove `#[cfg_attr(target_os = "linux", ignore)]` from both tests
+- [ ] No regressions in other tests (24 tests still passing)
+- [ ] Understanding of why these cases failed and how the fix works
+
+## Test Commands
+
+```bash
+# Run failing tests individually
+cargo test --release test_dylib_example
+cargo test --release test_rlib_example
+
+# Check what jonesy detects
+cd examples/dylib && ../../target/release/jonesy --lib
+cd examples/rlib && ../../target/release/jonesy --lib
+
+# Run all tests
+make test
+```
+
+## Notes
+
+- These are pre-existing issues in the ELF analysis path, unrelated to Phase 5 filtering
+- Phase 5 proved archive analysis works when properly filtered (staticlib passes)
+- Focus on understanding the root causes before implementing fixes

--- a/jonesy/src/call_graph.rs
+++ b/jonesy/src/call_graph.rs
@@ -93,7 +93,16 @@ fn build_plt_map(elf: &Elf, buffer: &[u8]) -> HashMap<u64, u64> {
     // Get the .rela.plt section data from the buffer
     let rela_plt_offset = rela_plt_section.sh_offset as usize;
     let rela_plt_size = rela_plt_section.sh_size as usize;
-    let rela_plt_data = &buffer[rela_plt_offset..rela_plt_offset + rela_plt_size];
+
+    // Guard against malformed/truncated ELF files
+    let Some(rela_plt_end) = rela_plt_offset.checked_add(rela_plt_size) else {
+        return plt_map;
+    };
+    if rela_plt_end > buffer.len() {
+        return plt_map;
+    }
+
+    let rela_plt_data = &buffer[rela_plt_offset..rela_plt_end];
 
     // Each Rela entry is 24 bytes on 64-bit
     let num_relocs = rela_plt_size / 24;
@@ -906,13 +915,29 @@ mod tests {
                     "PLT map should contain entries for dylib"
                 );
 
-                // Verify that PLT addresses are in the expected range
-                // (PLT section typically starts around 0x71940 for this binary)
+                // Get actual .plt section bounds from ELF metadata
+                let plt_section = elf
+                    .section_headers
+                    .iter()
+                    .find(|sh| {
+                        elf.shdr_strtab
+                            .get_at(sh.sh_name)
+                            .map(|n| n == ".plt")
+                            .unwrap_or(false)
+                    })
+                    .expect("ELF dylib should have .plt section");
+
+                let plt_start = plt_section.sh_addr;
+                let plt_end = plt_start + plt_section.sh_size;
+
+                // Verify that PLT addresses fall within the actual .plt section
                 for (plt_addr, target_addr) in &plt_map {
                     assert!(
-                        *plt_addr > 0x70000 && *plt_addr < 0x80000,
-                        "PLT address {:#x} should be in PLT section range",
-                        plt_addr
+                        *plt_addr >= plt_start && *plt_addr < plt_end,
+                        "PLT address {:#x} should be in .plt section [{:#x}, {:#x})",
+                        plt_addr,
+                        plt_start,
+                        plt_end
                     );
                     assert!(
                         *target_addr > 0,
@@ -940,24 +965,33 @@ mod tests {
             if let Ok(elf) = Elf::parse(&buffer) {
                 let plt_map = build_plt_map(&elf, &buffer);
 
-                // Look for rust_panic in the ELF dynamic symbols to verify mapping exists
-                let mut found_rust_panic_mapping = false;
-                for (plt_addr, target_addr) in &plt_map {
-                    // Check if this maps to the rust_panic function (around 0x74f20)
-                    if *target_addr > 0x74000 && *target_addr < 0x75000 {
-                        // Verify it's mapped from a PLT stub
-                        assert!(
-                            *plt_addr < *target_addr,
-                            "PLT stub should have lower address than function"
-                        );
-                        found_rust_panic_mapping = true;
+                // Look for rust_panic in the ELF dynamic symbols
+                let rust_panic_addr = elf.dynsyms.iter().find_map(|sym| {
+                    if sym.st_value > 0 {
+                        if let Some(name) = elf.dynstrtab.get_at(sym.st_name) {
+                            if name.contains("rust_panic") {
+                                return Some(sym.st_value);
+                            }
+                        }
                     }
+                    None
+                });
+
+                // Verify PLT map contains the rust_panic function if it exists
+                if let Some(rust_panic_target) = rust_panic_addr {
+                    let found_mapping = plt_map.values().any(|&target| target == rust_panic_target);
+                    assert!(
+                        found_mapping,
+                        "PLT map should contain mapping to rust_panic at {:#x}",
+                        rust_panic_target
+                    );
                 }
 
-                // Should have found at least one panic-related mapping
+                // At minimum, should have a reasonable number of PLT entries
                 assert!(
-                    found_rust_panic_mapping || plt_map.len() > 100,
-                    "Should have PLT mappings for panic functions or a reasonable number of entries"
+                    plt_map.len() > 50,
+                    "Dylib should have substantial number of PLT entries, found {}",
+                    plt_map.len()
                 );
             }
         }

--- a/jonesy/src/call_graph.rs
+++ b/jonesy/src/call_graph.rs
@@ -858,4 +858,124 @@ mod tests {
         assert!(info.caller_file.is_none());
         assert!(info.line.is_none());
     }
+
+    // Tests for PLT resolution (ELF-specific)
+
+    #[test]
+    fn test_resolve_plt_stub_with_mapping() {
+        let mut plt_map = HashMap::new();
+        plt_map.insert(0x71ee0, 0x74f20); // PLT stub -> actual function
+
+        // Should resolve PLT stub to actual function
+        let resolved = resolve_plt_stub(0x71ee0, &plt_map);
+        assert_eq!(resolved, 0x74f20);
+    }
+
+    #[test]
+    fn test_resolve_plt_stub_without_mapping() {
+        let plt_map = HashMap::new();
+
+        // Should return original address when not in PLT map
+        let resolved = resolve_plt_stub(0x12345, &plt_map);
+        assert_eq!(resolved, 0x12345);
+    }
+
+    #[test]
+    fn test_resolve_plt_stub_passthrough() {
+        let mut plt_map = HashMap::new();
+        plt_map.insert(0x1000, 0x2000);
+
+        // Address not in map should pass through unchanged
+        let resolved = resolve_plt_stub(0x3000, &plt_map);
+        assert_eq!(resolved, 0x3000);
+    }
+
+    #[test]
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    fn test_build_plt_map_with_real_elf() {
+        // Test with the dylib example binary if it exists
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let dylib_path = format!(
+            "{}/../../target/debug/libdylib_example.so",
+            manifest_dir
+        );
+
+        if let Ok(buffer) = std::fs::read(&dylib_path) {
+            if let Ok(elf) = Elf::parse(&buffer) {
+                let plt_map = build_plt_map(&elf, &buffer);
+
+                // The map should not be empty for a dylib with PLT
+                assert!(
+                    !plt_map.is_empty(),
+                    "PLT map should contain entries for dylib"
+                );
+
+                // Verify that PLT addresses are in the expected range
+                // (PLT section typically starts around 0x71940 for this binary)
+                for (plt_addr, target_addr) in &plt_map {
+                    assert!(
+                        *plt_addr > 0x70000 && *plt_addr < 0x80000,
+                        "PLT address {:#x} should be in PLT section range",
+                        plt_addr
+                    );
+                    assert!(
+                        *target_addr > 0,
+                        "Target address {:#x} should be non-zero",
+                        target_addr
+                    );
+                    assert_ne!(
+                        plt_addr, target_addr,
+                        "PLT stub {:#x} should differ from target {:#x}",
+                        plt_addr, target_addr
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(all(target_os = "linux", target_arch = "aarch64"))]
+    fn test_build_plt_map_resolves_rust_panic() {
+        // Test that rust_panic PLT stub is correctly mapped
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let dylib_path = format!(
+            "{}/../../target/debug/libdylib_example.so",
+            manifest_dir
+        );
+
+        if let Ok(buffer) = std::fs::read(&dylib_path) {
+            if let Ok(elf) = Elf::parse(&buffer) {
+                let plt_map = build_plt_map(&elf, &buffer);
+
+                // Look for rust_panic in the ELF dynamic symbols to verify mapping exists
+                let mut found_rust_panic_mapping = false;
+                for (plt_addr, target_addr) in &plt_map {
+                    // Check if this maps to the rust_panic function (around 0x74f20)
+                    if *target_addr > 0x74000 && *target_addr < 0x75000 {
+                        // Verify it's mapped from a PLT stub
+                        assert!(
+                            *plt_addr < *target_addr,
+                            "PLT stub should have lower address than function"
+                        );
+                        found_rust_panic_mapping = true;
+                    }
+                }
+
+                // Should have found at least one panic-related mapping
+                assert!(
+                    found_rust_panic_mapping || plt_map.len() > 100,
+                    "Should have PLT mappings for panic functions or a reasonable number of entries"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_build_plt_map_empty_for_non_elf() {
+        // Non-ELF binaries should return empty map (this tests the ELF-specific logic)
+        // We can't easily test this without a real ELF, but we can verify the function exists
+        let empty_map: HashMap<u64, u64> = HashMap::new();
+        let result = resolve_plt_stub(0x1000, &empty_map);
+        assert_eq!(result, 0x1000, "Empty PLT map should pass through address");
+    }
 }

--- a/jonesy/src/call_graph.rs
+++ b/jonesy/src/call_graph.rs
@@ -8,7 +8,6 @@ use capstone::arch::BuildsCapstone;
 use capstone::{Capstone, arch};
 use dashmap::DashMap;
 use goblin::elf::Elf;
-use goblin::elf::reloc::*;
 use goblin::mach::MachO;
 use rayon::prelude::*;
 use rustc_demangle::demangle;
@@ -107,7 +106,7 @@ fn build_plt_map(elf: &Elf, buffer: &[u8]) -> HashMap<u64, u64> {
         }
 
         // Parse Rela structure (64-bit): r_offset (8), r_info (8), r_addend (8)
-        let r_offset = u64::from_le_bytes(rela_plt_data[offset..offset + 8].try_into().unwrap());
+        let _r_offset = u64::from_le_bytes(rela_plt_data[offset..offset + 8].try_into().unwrap());
         let r_info = u64::from_le_bytes(rela_plt_data[offset + 8..offset + 16].try_into().unwrap());
         let _r_addend =
             i64::from_le_bytes(rela_plt_data[offset + 16..offset + 24].try_into().unwrap());

--- a/jonesy/src/call_graph.rs
+++ b/jonesy/src/call_graph.rs
@@ -894,10 +894,7 @@ mod tests {
     fn test_build_plt_map_with_real_elf() {
         // Test with the dylib example binary if it exists
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let dylib_path = format!(
-            "{}/../../target/debug/libdylib_example.so",
-            manifest_dir
-        );
+        let dylib_path = format!("{}/../../target/debug/libdylib_example.so", manifest_dir);
 
         if let Ok(buffer) = std::fs::read(&dylib_path) {
             if let Ok(elf) = Elf::parse(&buffer) {
@@ -937,10 +934,7 @@ mod tests {
     fn test_build_plt_map_resolves_rust_panic() {
         // Test that rust_panic PLT stub is correctly mapped
         let manifest_dir = env!("CARGO_MANIFEST_DIR");
-        let dylib_path = format!(
-            "{}/../../target/debug/libdylib_example.so",
-            manifest_dir
-        );
+        let dylib_path = format!("{}/../../target/debug/libdylib_example.so", manifest_dir);
 
         if let Ok(buffer) = std::fs::read(&dylib_path) {
             if let Ok(elf) = Elf::parse(&buffer) {

--- a/jonesy/src/call_graph.rs
+++ b/jonesy/src/call_graph.rs
@@ -7,6 +7,8 @@ use crate::sym::SymbolIndex;
 use capstone::arch::BuildsCapstone;
 use capstone::{Capstone, arch};
 use dashmap::DashMap;
+use goblin::elf::Elf;
+use goblin::elf::reloc::*;
 use goblin::mach::MachO;
 use rayon::prelude::*;
 use rustc_demangle::demangle;
@@ -53,6 +55,94 @@ const BL_OPCODE: u32 = 0x94000000;
 /// ARM64 B instruction mask: bits [31:26] must be 000101
 const B_MASK: u32 = 0xFC000000;
 const B_OPCODE: u32 = 0x14000000;
+
+/// Build a mapping from PLT stub addresses to actual function addresses using ELF relocations.
+/// Returns a HashMap mapping PLT address -> target function address.
+///
+/// PLT (Procedure Linkage Table) entries are used for lazy symbol resolution in shared libraries.
+/// Each PLT entry corresponds to a relocation in .rela.plt which points to the actual function.
+fn build_plt_map(elf: &Elf, buffer: &[u8]) -> HashMap<u64, u64> {
+    let mut plt_map = HashMap::new();
+
+    // Find .plt section
+    let plt_section = elf.section_headers.iter().find(|sh| {
+        elf.shdr_strtab
+            .get_at(sh.sh_name)
+            .map(|n| n == ".plt")
+            .unwrap_or(false)
+    });
+
+    let Some(plt_section) = plt_section else {
+        eprintln!("[PLT] No .plt section found in ELF");
+        return plt_map;
+    };
+
+    let plt_base = plt_section.sh_addr;
+
+    // Find .rela.plt section to get relocations
+    let rela_plt_section = elf.section_headers.iter().find(|sh| {
+        elf.shdr_strtab
+            .get_at(sh.sh_name)
+            .map(|n| n == ".rela.plt")
+            .unwrap_or(false)
+    });
+
+    let Some(rela_plt_section) = rela_plt_section else {
+        return plt_map;
+    };
+
+    // Get the .rela.plt section data from the buffer
+    let rela_plt_offset = rela_plt_section.sh_offset as usize;
+    let rela_plt_size = rela_plt_section.sh_size as usize;
+    let rela_plt_data = &buffer[rela_plt_offset..rela_plt_offset + rela_plt_size];
+
+    // Each Rela entry is 24 bytes on 64-bit
+    let num_relocs = rela_plt_size / 24;
+
+    // Parse each relocation entry
+    for index in 0..num_relocs {
+        let offset = index * 24;
+        if offset + 24 > rela_plt_data.len() {
+            break;
+        }
+
+        // Parse Rela structure (64-bit): r_offset (8), r_info (8), r_addend (8)
+        let r_offset = u64::from_le_bytes(rela_plt_data[offset..offset + 8].try_into().unwrap());
+        let r_info = u64::from_le_bytes(rela_plt_data[offset + 8..offset + 16].try_into().unwrap());
+        let _r_addend =
+            i64::from_le_bytes(rela_plt_data[offset + 16..offset + 24].try_into().unwrap());
+
+        // Extract symbol index from r_info (upper 32 bits)
+        let sym_index = (r_info >> 32) as usize;
+
+        // PLT entry address = plt_base + 32 + (index * 16)
+        let plt_addr = plt_base + 32 + (index as u64 * 16);
+
+        // Look up symbol and get its value (actual function address)
+        if let Some(sym) = elf.dynsyms.get(sym_index) {
+            let target_addr = sym.st_value;
+            if target_addr != 0 {
+                plt_map.insert(plt_addr, target_addr);
+            }
+        }
+    }
+
+    plt_map
+}
+
+/// Resolve a PLT (Procedure Linkage Table) stub address to the actual function address.
+///
+/// In ELF shared libraries (dylib), calls often go through PLT stubs for dynamic linking.
+/// For example:
+///   - PLT stub: 0x71ee0 <rust_panic@plt>
+///   - Actual function: 0x74f20 <rust_panic>
+///
+/// This function looks up the target address in the PLT map and returns the actual function address.
+///
+/// Returns the resolved address, or the original address if not a PLT stub.
+fn resolve_plt_stub(target_addr: u64, plt_map: &HashMap<u64, u64>) -> u64 {
+    plt_map.get(&target_addr).copied().unwrap_or(target_addr)
+}
 
 /// Decode ARM64 BL/B instruction target address from raw bytes.
 /// BL encoding: 100101 imm26
@@ -202,6 +292,13 @@ impl<'a> CallGraph<'a> {
         buffer: &[u8],
         symbol_index: Option<&'a SymbolIndex>,
     ) -> Result<Self, Box<dyn std::error::Error>> {
+        // Build PLT map for ELF binaries (for resolving PLT stubs to actual functions)
+        let plt_map = if let BinaryRef::Elf(elf) = binary {
+            build_plt_map(elf, buffer)
+        } else {
+            HashMap::new()
+        };
+
         let text_section_name = binary.text_section_name();
         let Some((text_addr, text_data)) = binary.find_section(buffer, text_section_name) else {
             return Ok(Self {
@@ -224,7 +321,10 @@ impl<'a> CallGraph<'a> {
                 && let Some((func_addr, func_name)) =
                     symbol_index.and_then(|idx| idx.find_containing(data.address))
             {
-                edges.entry(call_target).or_default().push(CallerInfo {
+                // Resolve PLT stub to actual function address (for ELF dylib support)
+                let resolved_target = resolve_plt_stub(call_target, &plt_map);
+
+                edges.entry(resolved_target).or_default().push(CallerInfo {
                     caller_name: Cow::Borrowed(func_name), // No allocation - borrows from SymbolIndex
                     caller_start_address: func_addr,
                     caller_file: None,
@@ -257,6 +357,13 @@ impl<'a> CallGraph<'a> {
         project_context: &ProjectContext,
     ) -> Result<Self, Box<dyn std::error::Error>> {
         use std::time::Instant;
+
+        // Build PLT map for ELF binaries (for resolving PLT stubs to actual functions)
+        let plt_map = if let BinaryRef::Elf(elf) = binary {
+            build_plt_map(elf, binary_buffer)
+        } else {
+            HashMap::new()
+        };
 
         // Pre-load DWARF info once (shared across threads)
         let step = Instant::now();
@@ -339,7 +446,9 @@ impl<'a> CallGraph<'a> {
                     project_context,
                 )
             {
-                edges.entry(target).or_default().push(caller_info);
+                // Resolve PLT stub to actual function address (for ELF dylib support)
+                let resolved_target = resolve_plt_stub(target, &plt_map);
+                edges.entry(resolved_target).or_default().push(caller_info);
             }
         });
         if show_timings {

--- a/jonesy/tests/integration_tests.rs
+++ b/jonesy/tests/integration_tests.rs
@@ -617,10 +617,6 @@ fn test_cdylib_example() {
 }
 
 #[test]
-#[cfg_attr(
-    target_os = "linux",
-    ignore = "Entry point detection issue - see PHASE6_HANDOFF.md"
-)]
 fn test_dylib_example() {
     setup();
     test_example("dylib");


### PR DESCRIPTION
## Objective

Fix the two remaining test failures on Linux aarch64 that were ignored in Phase 5:

1. **test_dylib_example** - 42 missing panics ✅ **FIXED**
2. **test_rlib_example** - 2 missing panics (conditional value tracking issue)

## Progress Update

### ✅ Issue 1: test_dylib_example - FIXED

**Root Cause:** PLT (Procedure Linkage Table) stub resolution issue
- Entry points were at actual function addresses (e.g., `rust_panic` at `0x74f20`)
- Call graph tracked calls to PLT stubs (e.g., `0x71ee0`)
- Address mismatch meant 0 callers found → 0 panics detected

**Solution:** 
- Implemented `build_plt_map()` to parse `.rela.plt` ELF section
- Maps PLT stub addresses to actual function addresses
- Integrated into `CallGraph::build()` and `build_with_debug_info()`

**Technical Details:**
Each `.rela.plt` relocation corresponds to a PLT entry:
- PLT entry N address = `plt_base + 32 + (N * 16)` (ARM64: 16-byte entries, 32-byte resolver)
- Parse Rela structure (24 bytes): `r_offset`, `r_info`, `r_addend`
- Extract symbol index from `r_info` (upper 32 bits)
- Look up symbol to get actual function address

**Test Results:**
✅ test_dylib_example now passes - detects 45 panics on Linux
✅ All 25 integration tests pass
✅ No regressions

### 🔄 Issue 2: test_rlib_example - TODO

**Problem:** Missing 2 unwrap calls that use `rand::Rng` to create runtime-conditional Option/Result values.

**Missing Lines:**
- `examples/rlib/src/module/mod.rs:10` - `opt.unwrap()` after conditional Some/None
- `examples/rlib/src/module/mod.rs:22` - `result.unwrap()` after conditional Ok/Err

**Investigation Plan:**
- Check if simple conditionals (without rand) are detected
- Debug why panic paths aren't followed through conditional value creation
- Verify line number mapping is correct

## Success Criteria

- [x] test_dylib_example passes (42 panics detected) ✅
- [ ] test_rlib_example passes (2 missing unwraps detected)
- [x] Remove `#[cfg_attr(target_os = "linux", ignore)]` from test_dylib_example ✅
- [ ] Remove `#[cfg_attr(target_os = "linux", ignore)]` from test_rlib_example
- [x] No regressions in other tests (25 tests passing) ✅
- [ ] CI passes on both macOS and Linux ARM

## Changes

### Commit: fix: Resolve PLT stubs to actual functions for ELF dylib support

- `jonesy/src/call_graph.rs`: Add PLT resolution support
  - New `build_plt_map()` function
  - Integration into call graph building
- `jonesy/tests/integration_tests.rs`: Remove ignore attribute from test_dylib_example

## Context

These are pre-existing detection issues in the ELF analysis path, unrelated to the Phase 5 filtering work. Phase 5 proved that archive analysis works correctly when properly filtered (staticlib now passes in <1s).

Related: #231

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)