### PR TITLE
Phase 6 Part 2: Fix rlib unwrap detection for inlined stdlib calls

### DIFF
--- a/jonesy/src/library_call_graph.rs
+++ b/jonesy/src/library_call_graph.rs
@@ -361,7 +361,6 @@ impl LibraryCallGraph {
                 // For .o files, use section name to disambiguate overlapping section-relative addresses
                 // target_name contains the section (e.g., ".text._ZN12rlib_example6module15cause_assert_eq...")
                 let (file, line, column) = if let Some(lt) = line_lookup.as_ref() {
-                    // Try section-aware lookup first (most precise for .o files)
                     lt.lookup_for_function_and_section(
                         call_site_addr,
                         &func_name,
@@ -383,22 +382,32 @@ impl LibraryCallGraph {
                 // If call site points to non-crate code (stdlib/dependency), try to find
                 // the last crate source line between function start and call site.
                 // IMPORTANT: For archive (.o) files, func_addr may be section-relative (often 0),
-                // not absolute. In that case, skip range search to avoid matching wrong functions.
+                // not absolute. In that case, use section-aware lookup instead of address range.
                 let (file, line, column) = if file
                     .as_ref()
                     .is_some_and(|f| !project_context.is_crate_source(f))
                 {
-                    // Only use range search if func_addr looks like an absolute address (> 0x1000)
-                    // For .o files with section-relative addresses, skip to avoid false matches
+                    // For absolute addresses (linked binaries), use address range search
                     if func_addr > 0x1000
                         && let Some(lt) = line_lookup.as_ref()
                         && let Some((crate_file, crate_line, crate_col)) =
                             lt.get_crate_line_in_range(func_addr, call_site_addr, project_context)
                     {
                         (Some(crate_file), Some(crate_line), crate_col)
+                    }
+                    // For section-relative addresses (.o files), use section-aware lookup
+                    else if let Some(lt) = line_lookup.as_ref()
+                        && let Some((crate_file, crate_line, crate_col)) = lt
+                            .get_crate_line_for_function_and_section(
+                                call_site_addr,
+                                &func_name,
+                                Some(target_name),
+                                project_context,
+                            )
+                    {
+                        (Some(crate_file), Some(crate_line), crate_col)
                     } else {
-                        // For section-relative addresses or if range search fails,
-                        // we can't reliably find the crate line - skip this call site
+                        // No fallback worked - skip this call site
                         (None, None, None)
                     }
                 } else {

--- a/jonesy/src/object_line_table.rs
+++ b/jonesy/src/object_line_table.rs
@@ -415,4 +415,53 @@ impl ObjectLineTable {
 
         None
     }
+
+    /// Find the last crate source line entry for a specific function/section up to call_site_addr.
+    /// This works for .o files with section-relative addresses (where func_addr may be 0).
+    ///
+    /// # Arguments
+    /// * `call_site_addr` - The call site address (section-relative for .o files)
+    /// * `function_name` - Function name for matching
+    /// * `section_name` - Optional section name for precise matching
+    /// * `project_context` - Project context to identify crate source files
+    pub(crate) fn get_crate_line_for_function_and_section(
+        &self,
+        call_site_addr: u64,
+        function_name: &str,
+        section_name: Option<&str>,
+        project_context: &ProjectContext,
+    ) -> Option<(String, u32, Option<u32>)> {
+        if self.entries.is_empty() {
+            return None;
+        }
+
+        // Extract the plain function name (last component after ::)
+        let plain_name = function_name.rsplit("::").next().unwrap_or(function_name);
+
+        // Find all entries for this function/section up to call_site_addr
+        let candidates: Vec<&ObjectLineEntry> = self
+            .entries
+            .iter()
+            .filter(|e| {
+                e.address <= call_site_addr
+                    && e.function_name
+                        .as_ref()
+                        .is_some_and(|f| f.contains(plain_name) || f.contains(function_name))
+                    && (section_name.is_none()
+                        || e.section_name.as_deref() == section_name
+                        || e.section_name
+                            .as_ref()
+                            .is_some_and(|s| section_name.is_some_and(|sn| s.contains(sn))))
+            })
+            .collect();
+
+        // Search backwards through candidates to find the last crate source entry
+        for entry in candidates.iter().rev() {
+            if project_context.is_crate_source(&entry.file) {
+                return Some((entry.file.clone(), entry.line, entry.column));
+            }
+        }
+
+        None
+    }
 }

--- a/jonesy/tests/integration_tests.rs
+++ b/jonesy/tests/integration_tests.rs
@@ -515,10 +515,6 @@ fn test_panic_example() {
 
 // Library-only analysis is now implemented for rlib archives
 #[test]
-#[cfg_attr(
-    target_os = "linux",
-    ignore = "Conditional value tracking issue - see PHASE6_HANDOFF.md"
-)]
 fn test_rlib_example() {
     setup();
     test_example("rlib");


### PR DESCRIPTION
## Summary
- Fixes unwrap() and unwrap_err() detection in .rlib files when inlined stdlib points to non-crate source
- Adds section-aware DWARF fallback for .o files with section-relative addresses
- Removes Linux ignore attribute from test_rlib_example

## Problem
When `unwrap()` or `unwrap_err()` get inlined, the DWARF line info for the call to `unwrap_failed` points to stdlib code (`/rustc/.../option.rs` or `result.rs`). For `.o` files with section-relative addresses (func_addr=0), the existing fallback range search was skipped, leaving no line info and causing jonesy to miss these panics.

## Solution
Added `get_crate_line_for_function_and_section()` method that finds the correct user source line even when addresses are section-relative by filtering line entries by function name and section name.

## Test Results
- ✅ test_rlib_example now passes on Linux (previously ignored)
- ✅ All 26 integration tests pass
- ✅ Detects all 21 expected panics in rlib_example (was 19)

## Changes
- `object_line_table.rs`: Add `get_crate_line_for_function_and_section` method
- `library_call_graph.rs`: Use section-aware lookup for .o files (func_addr <= 0x1000)
- `integration_tests.rs`: Remove Linux ignore from test_rlib_example

Closes #231 (Phase 6 Part 2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)