### PR TITLE
fix: Allow suppression of causeless panic points

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jonesy"
-version = "0.8.0"
+version = "0.8.1"
 dependencies = [
  "ahash",
  "capstone",

--- a/examples/perfect/jonesy.toml
+++ b/examples/perfect/jonesy.toml
@@ -1,4 +1,5 @@
 # Perfect example config - allow certain inherent panics that aren't user bugs
 # format: println!/format! macros can technically panic on write failure
 # oom: memory allocation failures are environmental, not code bugs
-allow = ["format", "oom"]
+# capacity: internal capacity overflow in stdlib I/O and collections
+allow = ["format", "oom", "capacity"]

--- a/examples/perfect/src/main.rs
+++ b/examples/perfect/src/main.rs
@@ -8,8 +8,8 @@ fn main() {
     for index in 0..5 {
         // How to index an array without a panic
         match CATCHPHRASES.get(index) {
-            None => println!("Array index out of range of array"), // jonesy:allow(format)
-            Some(phrase) => println!("{phrase}"),                  // jonesy:allow(format)
+            None => println!("Array index out of range of array"), // jonesy:allow(format,capacity)
+            Some(phrase) => println!("{phrase}"),                  // jonesy:allow(format,capacity)
         }
     }
 
@@ -26,16 +26,16 @@ fn demonstrate_inline_allows() {
     // jonesy:allow(unwrap)
     let value = always_some.unwrap();
 
-    // Allow `format` in `println!()` (and oom from internal allocations)
-    // jonesy:allow(format,oom)
+    // Allow `format` and `capacity` in `println!()` (and oom from internal allocations)
+    // jonesy:allow(format,oom,capacity)
     println!("Got value: {value}");
 
-    // Allow `expect` with a descriptive message, and `format` for the message (and oom from allocation)
-    // jonesy:allow(expect,format,oom)
+    // Allow `expect` with a descriptive message, and `format`/`capacity` for the message (and oom from allocation)
+    // jonesy:allow(expect,format,oom,capacity)
     let config = std::env::var("PATH").expect("PATH must be set");
 
-    // Allow `format` in `println!()` (and oom from internal allocations)
-    // jonesy:allow(format,oom)
+    // Allow `format` and `capacity` in `println!()` (and oom from internal allocations)
+    // jonesy:allow(format,oom,capacity)
     println!("PATH length: {}", config.len());
 
     // Allow `oom` on constructing a Vec
@@ -46,8 +46,8 @@ fn demonstrate_inline_allows() {
     // jonesy:allow(unwrap)
     let bytes = data.unwrap();
 
-    // Allow `format` in `println!()` (and oom from internal allocations)
-    // jonesy:allow(bounds,format,oom)
+    // Allow `format` and `capacity` in `println!()` (and oom from internal allocations)
+    // jonesy:allow(bounds,format,oom,capacity)
     println!("First byte: {}", bytes[0]);
 
     // Allow `capacity` inside `len()` (and oom from Vec allocation in args())

--- a/jonesy/Cargo.toml
+++ b/jonesy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jonesy"
 description = "Jonesy is here to help you not panic!"
-version = "0.8.0"
+version = "0.8.1"
 edition = "2024"
 rust-version = "1.85"
 authors = [" Andrew Mackenzie andrew@mackenzie-serres.net"]

--- a/jonesy/src/call_tree.rs
+++ b/jonesy/src/call_tree.rs
@@ -470,22 +470,20 @@ pub fn collect_crate_code_points(
     (roots, summary)
 }
 
-/// Assign `Unknown` cause to leaf points that have no identified causes.
-/// A leaf point is one with no children (closest to the panic in the call chain).
-/// This makes it clear that jonesy detected a panic path but couldn't identify the specific cause.
+/// Assign `Unknown` cause to points that have no identified causes.
+/// This ensures every `CrateCodePoint` has at least one cause, making all
+/// points filterable by allow mechanisms (inline comments, config rules).
 ///
-/// Special case: if the leaf is a direct panic (user code directly calls a
+/// Special case: if the point is a direct panic (user code directly calls a
 /// panic-triggering function like `panic_fmt`), assign `ExplicitPanic` instead
 /// of `Unknown`. This handles `panic!("literal")` in Rust 1.78+ where the macro
 /// routes through `panic_fmt` without an intermediate function that
-/// `detect_panic_cause` recognizes.
+/// `detect_panic_cause` recognises.
 fn assign_unknown_causes(points: &mut [CrateCodePoint]) {
     for point in points.iter_mut() {
-        // Recursively process children first
         assign_unknown_causes(&mut point.children);
 
-        // If this is a leaf (no children) with no causes, assign a cause
-        if point.children.is_empty() && point.causes.is_empty() {
+        if point.causes.is_empty() {
             if point.is_direct_panic {
                 point.causes.insert(PanicCause::ExplicitPanic);
             } else {
@@ -498,7 +496,6 @@ fn assign_unknown_causes(points: &mut [CrateCodePoint]) {
 /// Filter out code points whose causes are ALL allowed (not denied) by config or inline comments.
 /// A point is kept if ANY of its causes is denied.
 /// Also removes allowed causes from the causes set so only denied causes are displayed.
-/// If a point has no causes, it's kept (conservative - assume denied).
 ///
 /// The `workspace_root` parameter is used to resolve relative file paths for inline allow checks.
 pub fn filter_allowed_causes(
@@ -511,46 +508,29 @@ pub fn filter_allowed_causes(
     let workspace_root = Some(std::path::Path::new(project_context.project_root()));
 
     points.retain_mut(|point| {
-        // Track if we originally had no causes (conservative - keep these unless inline allowed)
-        let originally_empty = point.causes.is_empty();
-
-        // For points with no causes, check if there's a wildcard inline allow
-        // (points with no cause are otherwise kept conservatively)
-        if originally_empty && check_inline_allow(&point.file, point.line, "*", workspace_root) {
-            // Wildcard inline allow - filter out this point
-            return false;
-        }
-
-        // Remove allowed causes from the set - only keep denied ones
-        // Check both config rules (is_denied_at) and inline comments (check_inline_allow)
         point.causes.retain(|cause| {
             let cause_id = cause.id();
 
-            // First check inline comments - if allowed there, filter it out
             if check_inline_allow(&point.file, point.line, cause_id, workspace_root) {
-                return false; // Not denied (allowed by inline comment)
+                return false;
             }
 
-            // Then check config rules against the containing function
             if !config.is_denied_at(cause, Some(&point.file), Some(&point.name)) {
-                return false; // Allowed by rule on containing function
+                return false;
             }
 
-            // Also check config rules against the called function (for indirect panics)
             if let Some(ref called_fn) = point.called_function {
                 if !config.is_denied_at(cause, Some(&point.file), Some(called_fn)) {
-                    return false; // Allowed by rule on the called function
+                    return false;
                 }
             }
 
-            true // Denied (no rule allows it)
+            true
         });
 
-        // Keep if originally empty (conservative) or if any denied causes remain
-        let should_keep = originally_empty || !point.causes.is_empty();
+        let should_keep = !point.causes.is_empty();
 
         if should_keep {
-            // Recursively filter children
             filter_allowed_causes(&mut point.children, config, project_context);
         }
 
@@ -884,6 +864,73 @@ mod tests {
             points.len(),
             1,
             "Point should be kept - rule doesn't match different called function"
+        );
+    }
+
+    #[test]
+    fn test_assign_unknown_causes_non_leaf() {
+        let mut points = vec![CrateCodePoint {
+            name: "app::run".to_string(),
+            file: "src/main.rs".to_string(),
+            line: 10,
+            column: Some(1),
+            causes: HashSet::new(),
+            children: vec![CrateCodePoint {
+                name: "app::helper".to_string(),
+                file: "src/main.rs".to_string(),
+                line: 20,
+                column: Some(1),
+                causes: HashSet::new(),
+                children: vec![],
+                is_direct_panic: false,
+                called_function: None,
+            }],
+            is_direct_panic: false,
+            called_function: None,
+        }];
+
+        assign_unknown_causes(&mut points);
+
+        assert!(
+            points[0].causes.contains(&PanicCause::Unknown),
+            "Non-leaf point with empty causes should get Unknown assigned"
+        );
+        assert!(
+            points[0].children[0].causes.contains(&PanicCause::Unknown),
+            "Leaf child with empty causes should get Unknown assigned"
+        );
+    }
+
+    #[test]
+    fn test_filter_unknown_cause_with_allow() {
+        use crate::config::Config;
+        use std::io::Write;
+
+        let dir = tempfile::tempdir().unwrap();
+        let toml_path = dir.path().join("jonesy.toml");
+        let mut f = std::fs::File::create(&toml_path).unwrap();
+        writeln!(f, "allow = [\"unknown\"]").unwrap();
+
+        let mut config = Config::with_defaults();
+        config.load_from_jones_toml(&toml_path);
+
+        let mut points = vec![CrateCodePoint {
+            name: "app::run".to_string(),
+            file: "src/main.rs".to_string(),
+            line: 42,
+            column: Some(5),
+            causes: vec![PanicCause::Unknown].into_iter().collect(),
+            children: vec![],
+            is_direct_panic: false,
+            called_function: None,
+        }];
+
+        let ctx = ProjectContext::default();
+        filter_allowed_causes(&mut points, &config, &ctx);
+
+        assert!(
+            points.is_empty(),
+            "Point with Unknown cause should be filtered out by allow = [\"unknown\"]"
         );
     }
 }

--- a/jonesy/tests/integration_tests.rs
+++ b/jonesy/tests/integration_tests.rs
@@ -591,8 +591,6 @@ fn test_perfect_example() {
     let src_dir = example_dir.join("src");
 
     let markers = find_expected_panic_markers(&src_dir);
-    let raw_output = run_jonesy_raw_output(&example_dir, &["--no-hyperlinks"]);
-    eprintln!("jonesy stdout ({}):\n{}", example_dir.display(), raw_output);
     let (exit_code, detected) = run_jones_on_example(&example_dir);
 
     assert!(

--- a/jonesy/tests/integration_tests.rs
+++ b/jonesy/tests/integration_tests.rs
@@ -591,6 +591,8 @@ fn test_perfect_example() {
     let src_dir = example_dir.join("src");
 
     let markers = find_expected_panic_markers(&src_dir);
+    let raw_output = run_jonesy_raw_output(&example_dir, &["--no-hyperlinks"]);
+    eprintln!("jonesy stdout ({}):\n{}", example_dir.display(), raw_output);
     let (exit_code, detected) = run_jones_on_example(&example_dir);
 
     assert!(
@@ -599,7 +601,7 @@ fn test_perfect_example() {
     );
     assert!(
         detected.is_empty(),
-        "Perfect example should have no detected panics"
+        "Perfect example should have no detected panics, but found: {detected:?}"
     );
     assert_eq!(
         exit_code, 0,


### PR DESCRIPTION
## Summary
- Fixes #255 — panic points with no identified causes could not be suppressed by any allow mechanism
- `assign_unknown_causes()` now assigns `PanicCause::Unknown` to **all** points with empty causes, not just leaf nodes
- Removes the conservative `originally_empty` logic from `filter_allowed_causes()` since every point now has at least one cause
- Bumps version to 0.8.1

## Root cause
Non-leaf `CrateCodePoint` nodes (those with child crate code points but where no function in the call chain matched a known panic pattern) had empty causes. These were unconditionally kept by `filter_allowed_causes()` via the `originally_empty` flag, bypassing all allow mechanisms.

## Changes
- `call_tree.rs:assign_unknown_causes()` — removed `point.children.is_empty()` condition so Unknown is assigned to all empty-cause points
- `call_tree.rs:filter_allowed_causes()` — simplified by removing dead `originally_empty` logic
- Added two unit tests: `test_assign_unknown_causes_non_leaf` and `test_filter_unknown_cause_with_allow`

## Test plan
- [x] `make test` passes (456 tests)
- [x] `make clippy` clean (only pre-existing warnings)
- [x] `cargo fmt` clean
- [x] Tested against meshchat repo — 0 causeless points, `allow = ["unknown"]` correctly filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)