### PR TITLE
fix: Inline allow overflow matches specific overflow variants

### DIFF
--- a/jonesy/src/inline_allows.rs
+++ b/jonesy/src/inline_allows.rs
@@ -94,10 +94,19 @@ pub fn check_inline_allow(
                 if causes.contains("*") || causes.contains(cause_id) {
                     return true;
                 }
-                // Check if any cause in the comment normalises to the same canonical ID
                 for c in &causes {
                     if let Some(canonical) = crate::panic_cause::PanicCause::normalise_id(c) {
                         if canonical == cause_id {
+                            return true;
+                        }
+                        // Parent ID matching: "overflow" in comment matches
+                        // "div_overflow", "rem_overflow", "shift_overflow"
+                        if canonical == "overflow"
+                            && matches!(
+                                cause_id,
+                                "overflow" | "div_overflow" | "rem_overflow" | "shift_overflow"
+                            )
+                        {
                             return true;
                         }
                     }


### PR DESCRIPTION
## Summary
- Fixes a bug where `// jonesy:allow(overflow)` in inline comments did not suppress specific overflow variants (`div_overflow`, `rem_overflow`, `shift_overflow`)
- Aligns inline allow behaviour with config file allow behaviour, where `parent_id()` matching already handled this
- Found while investigating #253 (which turned out to be a comment positioning issue in the pigg project, not a jonesy bug)

## Test plan
- [x] `make test` passes (456 tests)
- [x] `make clippy` clean
- [x] Verified against pigg project: 0 panic points with `allow(overflow)` correctly matching `div_overflow` findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)