### PR TITLE
feat: Propagate inline allow to callers within the same crate

### DIFF
--- a/examples/rlib/src/module/mod.rs
+++ b/examples/rlib/src/module/mod.rs
@@ -124,6 +124,12 @@ pub fn cause_allowed_overflow() {
     let _ = x + 1; // jonesy:allow(overflow)
 }
 
+/// Calls cause_allowed_overflow() — should NOT be flagged for overflow
+/// because the callee has an inline allow that stops propagation.
+pub fn caller_of_allowed_overflow() {
+    cause_allowed_overflow();
+}
+
 #[allow(clippy::useless_vec)]
 // Known limitation: slice index detection is platform-specific (see issue #59)
 pub fn cause_slice_index_oob() {

--- a/jonesy/benches/hot_paths.rs
+++ b/jonesy/benches/hot_paths.rs
@@ -336,6 +336,7 @@ fn bench_collect_crate_relationships(c: &mut Criterion) {
                     None,
                     None,
                     &project_context,
+                    Some(std::path::Path::new(project_context.project_root())),
                 );
                 black_box(points)
             })

--- a/jonesy/src/call_tree.rs
+++ b/jonesy/src/call_tree.rs
@@ -279,11 +279,18 @@ pub fn collect_crate_code_points_hierarchical(
     node: &CallTreeNode,
     project_context: &ProjectContext,
 ) -> Vec<CrateCodePoint> {
-    // First pass: collect all crate code points and their relationships
-    // Map: (file, line) -> (name, cause, set of child keys)
     let mut points: CodePointMap = CodePointMap::new();
+    let workspace_root = Some(std::path::Path::new(project_context.project_root()));
 
-    collect_crate_relationships(node, &mut points, None, None, None, project_context);
+    collect_crate_relationships(
+        node,
+        &mut points,
+        None,
+        None,
+        None,
+        project_context,
+        workspace_root,
+    );
 
     // All crate code points should be reported as roots.
     // Each point that can lead to a panic deserves its own entry,
@@ -376,8 +383,9 @@ pub fn collect_crate_relationships(
     points: &mut CodePointMap,
     child_crate_key: Option<CodePointKey>,
     current_cause: Option<PanicCause>,
-    immediate_callee: Option<&str>, // Name of function this node calls (toward panic)
+    immediate_callee: Option<&str>,
     project_context: &ProjectContext,
+    workspace_root: Option<&std::path::Path>,
 ) {
     // Try to detect panic cause from this node's function name
     let detected_cause = detect_panic_cause(&node.name).or(current_cause);
@@ -445,6 +453,20 @@ pub fn collect_crate_relationships(
 
     // When recursing to callers, the current node becomes the child
     // (since callers are further from panic, they are parents in our hierarchy)
+    // If this crate code point has an inline allow for the detected cause,
+    // don't propagate that cause to callers — the allow at this point
+    // covers the entire call subtree within the same crate.
+    let propagated_cause = if let (Some(key), Some(cause)) = (&node_key, &detected_cause) {
+        let cause_id = cause.id();
+        if crate::inline_allows::check_inline_allow(&key.0, key.1, cause_id, workspace_root) {
+            None
+        } else {
+            detected_cause.clone()
+        }
+    } else {
+        detected_cause.clone()
+    };
+
     let next_child = node_key.or(child_crate_key);
 
     for caller in &node.callers {
@@ -452,9 +474,10 @@ pub fn collect_crate_relationships(
             caller,
             points,
             next_child.clone(),
-            detected_cause.clone(),
+            propagated_cause.clone(),
             Some(&node.name),
             project_context,
+            workspace_root,
         );
     }
 }

--- a/jonesy/tests/integration_tests.rs
+++ b/jonesy/tests/integration_tests.rs
@@ -1699,11 +1699,32 @@ fn test_rlib_inline_allow_propagates_to_caller() {
     let example_dir = workspace_root.join("examples").join("rlib");
 
     let stdout = run_jonesy_raw_output(&example_dir, &["--no-hyperlinks", "--lib"]);
+    let detected = parse_jones_output(&stdout);
 
-    // The caller function should NOT appear with overflow
-    let caller_has_overflow = stdout
+    // Find actual line numbers from source to avoid hardcoding
+    let mod_path = example_dir.join("src/module/mod.rs");
+    let mod_content = fs::read_to_string(&mod_path).expect("Failed to read mod.rs");
+
+    let caller_line = mod_content
         .lines()
-        .any(|line| line.contains("caller_of_allowed_overflow") && line.contains("overflow"));
+        .enumerate()
+        .find(|(_, l)| l.trim() == "cause_allowed_overflow();")
+        .map(|(i, _)| (i + 1) as u32)
+        .expect("Could not find caller_of_allowed_overflow call line");
+
+    let allowed_line = mod_content
+        .lines()
+        .enumerate()
+        .find(|(_, l)| l.contains("jonesy:allow(overflow)"))
+        .map(|(i, _)| (i + 1) as u32)
+        .expect("Could not find inline allow line");
+
+    // The caller function should NOT have overflow in parsed detections
+    let caller_has_overflow = detected.iter().any(|p| {
+        p.file.ends_with("module/mod.rs")
+            && (caller_line.saturating_sub(1)..=caller_line + 1).contains(&p.line)
+            && p.causes.iter().any(|c| c.contains("overflow"))
+    });
 
     assert!(
         !caller_has_overflow,
@@ -1711,10 +1732,12 @@ fn test_rlib_inline_allow_propagates_to_caller() {
         stdout
     );
 
-    // The allowed function itself should also not appear (filtered by its own allow)
-    let allowed_has_overflow = stdout
-        .lines()
-        .any(|line| line.contains("cause_allowed_overflow") && line.contains("overflow"));
+    // The allowed function itself should also not appear
+    let allowed_has_overflow = detected.iter().any(|p| {
+        p.file.ends_with("module/mod.rs")
+            && (allowed_line.saturating_sub(1)..=allowed_line + 1).contains(&p.line)
+            && p.causes.iter().any(|c| c.contains("overflow"))
+    });
 
     assert!(
         !allowed_has_overflow,
@@ -1722,10 +1745,12 @@ fn test_rlib_inline_allow_propagates_to_caller() {
         stdout
     );
 
-    // But the non-allowed overflow (cause_arithmetic_overflow, line 111) should still appear
-    let has_denied_detection = stdout
-        .lines()
-        .any(|line| line.contains("mod.rs:111") && line.contains("overflow"));
+    // But the non-allowed overflow (cause_arithmetic_overflow) should still appear
+    let has_denied_detection = detected.iter().any(|p| {
+        p.file.ends_with("module/mod.rs")
+            && p.causes.iter().any(|c| c.contains("overflow"))
+            && !p.causes.iter().all(|c| c == "shift_overflow")
+    });
 
     assert!(
         has_denied_detection,

--- a/jonesy/tests/integration_tests.rs
+++ b/jonesy/tests/integration_tests.rs
@@ -1689,6 +1689,51 @@ fn test_rlib_inline_allow() {
     );
 }
 
+/// Test that inline allow propagates to callers within the same crate.
+/// `cause_allowed_overflow` has `// jonesy:allow(overflow)`.
+/// `caller_of_allowed_overflow` calls it and should NOT be flagged for overflow.
+#[test]
+fn test_rlib_inline_allow_propagates_to_caller() {
+    setup();
+    let workspace_root = find_workspace_root();
+    let example_dir = workspace_root.join("examples").join("rlib");
+
+    let stdout = run_jonesy_raw_output(&example_dir, &["--no-hyperlinks", "--lib"]);
+
+    // The caller function should NOT appear with overflow
+    let caller_has_overflow = stdout
+        .lines()
+        .any(|line| line.contains("caller_of_allowed_overflow") && line.contains("overflow"));
+
+    assert!(
+        !caller_has_overflow,
+        "caller_of_allowed_overflow should NOT be flagged for overflow — the callee's inline allow should propagate.\nOutput:\n{}",
+        stdout
+    );
+
+    // The allowed function itself should also not appear (filtered by its own allow)
+    let allowed_has_overflow = stdout
+        .lines()
+        .any(|line| line.contains("cause_allowed_overflow") && line.contains("overflow"));
+
+    assert!(
+        !allowed_has_overflow,
+        "cause_allowed_overflow should be suppressed by its inline allow.\nOutput:\n{}",
+        stdout
+    );
+
+    // But the non-allowed overflow (cause_arithmetic_overflow, line 111) should still appear
+    let has_denied_detection = stdout
+        .lines()
+        .any(|line| line.contains("mod.rs:111") && line.contains("overflow"));
+
+    assert!(
+        has_denied_detection,
+        "cause_arithmetic_overflow (without inline allow) should still be detected.\nOutput:\n{}",
+        stdout
+    );
+}
+
 /// Test that parallel .rlib processing produces identical results to sequential processing.
 /// This verifies that the parallel .o file processing implementation is deterministic.
 #[test]


### PR DESCRIPTION
## Summary
- Fixes #248 — inline allow comments now propagate to callers within the same crate
- If function B has `// jonesy:allow(expect)` and functions A and C call B, they no longer need their own allow comments for the same cause
- Eliminates redundant allow comments for the same root cause (e.g. internal expect in chrono)
- Cross-crate callers are NOT affected — propagation stays within the crate boundary

## How it works
During `collect_crate_relationships`, before propagating a detected cause to callers, checks if the current crate code point has an inline allow for that cause. If so, the cause is not propagated upward.

## Test plan
- [x] `make test` passes (461 tests)
- [x] `make clippy` clean
- [x] Verified rlib example: allowed overflow at line 124 not propagated to callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)