### PR TITLE
chore: Bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jonesy"
-version = "0.9.1"
+version = "0.10.0"
 dependencies = [
  "ahash",
  "capstone",

--- a/jonesy/Cargo.toml
+++ b/jonesy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "jonesy"
 description = "Jonesy is here to help you not panic!"
-version = "0.9.1"
+version = "0.10.0"
 edition = "2024"
 rust-version = "1.85"
 authors = [" Andrew Mackenzie andrew@mackenzie-serres.net"]


### PR DESCRIPTION
Version bump for three new features:
- `--direct-only` (#252)
- `--report-unused-rules` (#251)
- Inline allow propagation to callers (#248)

🤖 Generated with [Claude Code](https://claude.com/claude-code)